### PR TITLE
Improved installation process

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,20 +186,35 @@ and execution with `PJRT` for comparison, with some benchmarks.
 
 ## Installing
 
-**TLDR;**: **gopjrt** requires a C library installed and a plugin module. Run the script 
-[`cmd/install.sh`](https://github.com/gomlx/gopjrt/blob/main/cmd/install.sh) to 
-automatically install them (for CPU). 
-And in addition, run [`cmd/install_cuda.sh`](https://github.com/gomlx/gopjrt/blob/main/cmd/install_cuda.sh) to
-automatically install Nvidia's GPU support.
+### **TLDR;** 
 
+**gopjrt** requires a C library installed and a plugin module. For Linux (*), run the following script:
+
+```bash
+curl -sSf https://raw.githubusercontent.com/gomlx/gopjrt/main/cmd/install.sh | bash
+```
+
+For CUDA (NVidia GPU) support, in addition also run:
+
+```bash
+curl -sSf https://raw.githubusercontent.com/gomlx/gopjrt/main/cmd/install_cuda.sh | bash
+```
+
+(*) It would be awesome if someone could build a _mac/arm64_ version.
+
+### More details
+
+The two scripts [`cmd/install.sh`](https://github.com/gomlx/gopjrt/blob/main/cmd/install.sh) and [`cmd/install_cuda.sh`](https://github.com/gomlx/gopjrt/blob/main/cmd/install_cuda.sh) can be controlled to install in any arbitrary
+directory (by setting `GOPJRT_INSTALL_DIR`) and not to use `sudo` (by setting `GOPJRT_NOSUDO`). You many need
+to fiddle with `LD_LIBRARY_PATH` if the installation directory is not standard, and the `PJRT_PLUGIN_LIBRARY_PATH`
+to tell gopjrt where to find the plugins.
 
 There are two parts that needs installing: (1) XLA Builder library (it's a C++ wrapper); (2) PJRT plugins for the
 accelerator devices you want to support.
 
 The releases come with a prebuilt (1) XLA Builder library for _linux/amd64_ and (2) the PJRT for CPU,
-again only for _linux/amd64_. Just [download it from the latest release in GitHub](https://github.com/gomlx/gopjrt/releases/latest). 
-
-(*) It would be awesome if someone could build a _mac/arm64_ version.
+again only for _linux/amd64_. One can [download it from the latest release in GitHub](https://github.com/gomlx/gopjrt/releases/latest), or use the
+[`cmd/install.sh`](https://github.com/gomlx/gopjrt/blob/main/cmd/install.sh) script, which does exactly that.
 
 ### Installing XLA Builder
 
@@ -312,8 +327,6 @@ Or that your system library paths in `/etc/ld.so.conf` include `/usr/local/lib`.
 
 ## FAQ
 
-* **Why is [GoMLX](github.com/gomlx/gomlx) is not using `gopjrt` ?**
-  Not yet, soon.
 * **When is feature X from PJRT or XlaBuilder going to be supported ?**
   Yes, `gopjrt` doesn't wrap everything -- although it does cover the most common operations. 
   The simple ops and structs are auto-generated. But many require hand-writing.

--- a/cmd/install.sh
+++ b/cmd/install.sh
@@ -3,15 +3,26 @@
 # This script will install the XlaBuilder C wrapper library and the latest PJRT plugin for gopjrt
 # library. This should be all one need to use it.
 #
-# It uses `sudo` to gain access to admin to create the directories and uncompress the files.
+# Arguments (environment variables):
+#
+# GOPJRT_INSTALL_DIR: if not empty, defines the directory where to install the library. If empty, it install into `/usr/local`.
+# GOPJRT_NOSUDO: if not empty, prevent using sudo to install.
 #
 # Check install_cuda.sh to additionally install the PJRT plugin for CUDA -- for NVidia GPU support.
+#
+# To execute this without cloning the repository, one can do:
+#
+# curl -sSf https://raw.githubusercontent.com/gomlx/gopjrt/main/cmd/install.sh | bash
 #
 # See: https://github.com/gomlx/gopjrt?#installing
 set -e
 
 # Base installation directory:
-INSTALL_DIR="${INSTALL_DIR:-/usr/local}"
+GOPJRT_INSTALL_DIR="${GOPJRT_INSTALL_DIR:-/usr/local}"
+_SUDO="sudo"
+if [[ "${GOPJRT_NOSUDO}" != "" ]] ; then
+  _SUDO=""
+fi
 
 # Fetch address of resources for latest release:
 download_urls=$(mktemp --tmpdir gopjrt_urls.XXXXXXXX)
@@ -23,19 +34,26 @@ curl -s https://api.github.com/repos/gomlx/gopjrt/releases/latest \
 # Download XlaBuilder C wrapper library.
 url="$(grep gomlx_xlabuilder-linux-amd64.tar.gz "${download_urls}" | head -n 1)"
 printf "\nDownloading PJRT CPU plugin from ${url}\n"
-sudo printf "\tsudo authorized\n"
-pushd "${INSTALL_DIR}"
-curl -L "${url}" | sudo tar xzv
+
+if [[ "${_SUDO}" != "" ]] ; then
+  echo "Checking sudo authorization for installation"
+  ${_SUDO} printf "\tsudo authorized\n"
+fi
+mkdir -p "${GOPJRT_INSTALL_DIR}"
+pushd "${GOPJRT_INSTALL_DIR}"
+curl -L "${url}" | ${_SUDO} tar xzv
 ls -lh "lib/libgomlx_xlabuilder.so"
 popd
 
 # Download PJRT CPU plugin
 url="$(grep pjrt_c_api_cpu_plugin.so.gz "${download_urls}" | head -n 1)"
 printf "\nDownloading PJRT CPU plugin from ${url}\n"
-sudo printf "\tsudo authorized\n"
-sudo mkdir -p "${INSTALL_DIR}/lib/gomlx/pjrt"
-pushd "${INSTALL_DIR}/lib/gomlx/pjrt"
-curl -L "${url}" | gunzip | sudo bash -c 'cat > pjrt_c_api_cpu_plugin.so'
+if [[ "${_SUDO}" != "" ]] ; then
+  ${_SUDO} printf "\tsudo authorized\n"
+fi
+${_SUDO} mkdir -p "${GOPJRT_INSTALL_DIR}/lib/gomlx/pjrt"
+pushd "${GOPJRT_INSTALL_DIR}/lib/gomlx/pjrt"
+curl -L "${url}" | gunzip | ${_SUDO} bash -c 'cat > pjrt_c_api_cpu_plugin.so'
 ls -lh pjrt_c_api_cpu_plugin.so
 popd
 

--- a/cmd/install_cuda.sh
+++ b/cmd/install_cuda.sh
@@ -3,13 +3,26 @@
 # This script will install the CUDA PJRT plugin, to add support for Nvidia GPUs.
 # You should run `install.sh` first to install XlaBuilder C wrapper library (and the CPU plugin).
 #
+# Arguments (environment variables):
+#
+# GOPJRT_INSTALL_DIR: if not empty, defines the directory where to install the library. If empty, it install into `/usr/local`.
+# GOPJRT_NOSUDO: if not empty, prevent using sudo to install.
+#
 # It uses `sudo` to gain access to admin to create the directories and uncompress the files.
+#
+# To execute this without cloning the repository, one can do:
+#
+# curl -sSf https://raw.githubusercontent.com/gomlx/gopjrt/main/cmd/install_cuda.sh | bash
 #
 # See: https://github.com/gomlx/gopjrt?#installing
 set -e
 
 # Base installation directory:
-INSTALL_DIR="${INSTALL_DIR:-/usr/local}"
+GOPJRT_INSTALL_DIR="${GOPJRT_INSTALL_DIR:-/usr/local}"
+_SUDO="sudo"
+if [[ "${GOPJRT_NOSUDO}" != "" ]] ; then
+  _SUDO=""
+fi
 
 # Create a new virtual environment for Python (if one is not given).
 if [[ "${JAX_VENV_DIR}" == "" ]] ; then
@@ -24,21 +37,24 @@ printf "\nInstalling jax[cuda12] in ${JAX_VENV_DIR}:\n"
 pip install "jax[cuda12]"
 
 # Copy over PJRT CUDA plugin:
-sudo printf "\t- sudo authorized\n"
-sudo mkdir -p "${INSTALL_DIR}/lib/gomlx/pjrt"
-sudo rm -f "${INSTALL_DIR}/lib/gomlx/pjrt/pjrt_c_api_cuda_plugin.so"
-sudo cp -f "${JAX_VENV_DIR}/lib/python3."*"/site-packages/jax_plugins/xla_cuda12/xla_cuda_plugin.so" \
-  "${INSTALL_DIR}/lib/gomlx/pjrt/pjrt_c_api_cuda_plugin.so"
-ls -lh "${INSTALL_DIR}/lib/gomlx/pjrt/pjrt_c_api_cuda_plugin.so"
+if [[ "${_SUDO}" != "" ]] ; then
+  echo "Checking sudo authorization for installation"
+  ${_SUDO} printf "\tsudo authorized\n"
+fi
+${_SUDO} mkdir -p "${GOPJRT_INSTALL_DIR}/lib/gomlx/pjrt"
+${_SUDO} rm -f "${GOPJRT_INSTALL_DIR}/lib/gomlx/pjrt/pjrt_c_api_cuda_plugin.so"
+${_SUDO} cp -f "${JAX_VENV_DIR}/lib/python3."*"/site-packages/jax_plugins/xla_cuda12/xla_cuda_plugin.so" \
+  "${GOPJRT_INSTALL_DIR}/lib/gomlx/pjrt/pjrt_c_api_cuda_plugin.so"
+ls -lh "${GOPJRT_INSTALL_DIR}/lib/gomlx/pjrt/pjrt_c_api_cuda_plugin.so"
 
 # Copy over Nvidia drivers installed for JAX.
 printf "\t- removing previous Nvidia drivers installation for gomlx/gopjrt\n"
-sudo mkdir -p "${INSTALL_DIR}/lib/gomlx/nvidia"
-sudo rm -rf "${INSTALL_DIR}/lib/gomlx/nvidia/"*
+${_SUDO} mkdir -p "${GOPJRT_INSTALL_DIR}/lib/gomlx/nvidia"
+${_SUDO} rm -rf "${GOPJRT_INSTALL_DIR}/lib/gomlx/nvidia/"*
 printf "\t- copying over Nvidia drivers from Jax installation\n"
-sudo cp -r "${JAX_VENV_DIR}/lib/python3."*"/site-packages/nvidia/"* \
-  "${INSTALL_DIR}/lib/gomlx/nvidia/"
-ls -lh "${INSTALL_DIR}/lib/gomlx/nvidia/"
+${_SUDO} cp -r "${JAX_VENV_DIR}/lib/python3."*"/site-packages/nvidia/"* \
+  "${GOPJRT_INSTALL_DIR}/lib/gomlx/nvidia/"
+ls -lh "${GOPJRT_INSTALL_DIR}/lib/gomlx/nvidia/"
 
 # Clean up and finish.
 if [[ "${tmp_venv_dir}" != "" ]] ; then

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Added memory layout information in buffer-to-host transfers: required for TPU.
 * Included C error message when reporting PJRT plugin failures.
+* Added GOPJRT_NOSUDO and GOPJRT_INSTALL_DIR to control `cmd/install.sh` and `cmd/install_cuda.sh`.
+* Improved installation instructions to install directly from Github using `curl`, without the need to clone the repository.
 
 # v0.4.0 - 2024-09-23
 


### PR DESCRIPTION
* Added GOPJRT_NOSUDO and GOPJRT_INSTALL_DIR to control `cmd/install.sh` and `cmd/install_cuda.sh`.
* Improved installation instructions to install directly from Github using `curl`, without the need to clone the repository.
