### PR TITLE
Replaced C++ `xla::StatusOr` by `absl::StatusOr`

### DIFF
--- a/c/gomlx/xlabuilder/BUILD
+++ b/c/gomlx/xlabuilder/BUILD
@@ -8,10 +8,10 @@ gomlx_xlabuilder_deps = [
     "@com_google_absl//absl/base:log_severity",
     "@com_google_absl//absl/log:initialize",
     "@com_google_absl//absl/status",
+    "@com_google_absl//absl/status:statusor",
     "@xla//xla:comparison_util",
     "@xla//xla:literal",
     "@xla//xla:shape_util",
-    "@xla//xla:statusor",
     "@xla//xla:types",
     "@xla//xla:util",
     "@xla//xla:xla_data_proto_cc",
@@ -29,7 +29,7 @@ stablehlo_deps = [
     "@stablehlo//:register",
     "@stablehlo//:stablehlo_serialization",
     "@xla//xla/hlo/translate/hlo_to_mhlo:hlo_to_mlir_hlo",
- ]
+]
 
 config_setting(
     name = "use_stablehlo",
@@ -40,18 +40,18 @@ cc_library(
     name = "xlabuilder",
     srcs = glob(["*.cpp"]),
     hdrs = glob(["*.h"]),
+    defines = select({
+        ":use_stablehlo": ["USE_STABLEHLO"],
+        "//conditions:default": [],
+    }),
     # SKIP_ABSL_INITIALIZE_LOG: this will trigger skipping of the call to `absl::InitializeLog()`
     # to prevent double-calling, in case whoever is linking GoMLX also calls it. Setting it may
     # lead to spurious logging by XLA library at startup up.
     # defines = ["SKIP_ABSL_INITIALIZE_LOG"],
     linkopts = ["-shared"],
-    defines = select({
-        ":use_stablehlo": ["USE_STABLEHLO"],
-        "//conditions:default": [],
-    }),
     deps = gomlx_xlabuilder_deps + select({
-             ":use_stablehlo": stablehlo_deps,
-             "//conditions:default": [],
+        ":use_stablehlo": stablehlo_deps,
+        "//conditions:default": [],
     }),
     alwayslink = True,
 )
@@ -62,8 +62,8 @@ cc_static_library(
     deps = gomlx_xlabuilder_deps + [
         ":xlabuilder",
     ] + select({
-             ":use_stablehlo": stablehlo_deps,
-             "//conditions:default": [],
+        ":use_stablehlo": stablehlo_deps,
+        "//conditions:default": [],
     }),
 )
 

--- a/c/gomlx/xlabuilder/shape.cpp
+++ b/c/gomlx/xlabuilder/shape.cpp
@@ -21,11 +21,8 @@
 
 #include "gomlx/xlabuilder/literal.h"
 #include "gomlx/xlabuilder/utils.h"
-
 #include "xla/literal.h"
-#include "xla/statusor.h"
 #include "xla/types.h"
-// #include "xla/xla_data.pb.h"
 
 using namespace std;
 

--- a/c/gomlx/xlabuilder/utils.cpp
+++ b/c/gomlx/xlabuilder/utils.cpp
@@ -19,7 +19,6 @@
 #include <string.h>
 
 #include "absl/log/initialize.h"
-#include "xla/statusor.h"
 
 const char *TF_LOG_LEVEL_ENV = "TF_CPP_MIN_LOG_LEVEL";
 

--- a/c/gomlx/xlabuilder/utils.h
+++ b/c/gomlx/xlabuilder/utils.h
@@ -16,13 +16,13 @@
 
 // utils.h holds several small C/Go connector tools:
 //
-// - handling of absl::Status and xla::StatusOr.
+// - handling of absl::Status and absl::StatusOr.
 // - C definitions of VectorPointers and VectorData
 // - Memory stats, usage and heap checker for leaks.
 
 #ifndef _GOMLX_XLABUILDER_STATUS_H
 #define _GOMLX_XLABUILDER_STATUS_H
-// utils.h holds the simplified C interface to absl::Status and xla::StatusOr
+// utils.h holds the simplified C interface to absl::Status and absl::StatusOr
 // objects.
 #include <stdlib.h>
 
@@ -76,8 +76,7 @@ typedef struct {
 #include <vector>
 
 #include "absl/status/status.h"
-#include "xla/statusor.h"
-// #include "xla/xla/shape_util.h"
+#include "absl/status/statusor.h"
 
 // Malloc is a convenience allocation of individual items or arrays (for n>1)
 // using C malloc, needed to interface in Go.
@@ -115,7 +114,8 @@ extern VectorPointers *c_vector_str(const std::vector<std::string> &v);
 // from the given one -- contents are transferred.
 XlaStatus *FromStatus(const absl::Status &status);
 
-template <typename T> StatusOr FromStatusOr(xla::StatusOr<std::unique_ptr<T>> &status_or) {
+// FromStatusOr with a unique_prt<T>: takes ownership of the pointer, returning it in the new StatusOr.
+template <typename T> StatusOr FromStatusOr(absl::StatusOr<std::unique_ptr<T>> &status_or) {
   StatusOr r;
   r.status =
       static_cast<XlaStatus *>(new absl::Status(std::move(status_or.status())));
@@ -126,7 +126,8 @@ template <typename T> StatusOr FromStatusOr(xla::StatusOr<std::unique_ptr<T>> &s
   return r;
 }
 
-template <typename T> StatusOr FromStatusOr(xla::StatusOr<T *> &status_or) {
+// FromStatusOr with a *T pointer.
+template <typename T> StatusOr FromStatusOr(absl::StatusOr<T *> &status_or) {
   StatusOr r;
   r.status =
       static_cast<XlaStatus *>(new absl::Status(std::move(status_or.status())));

--- a/c/gomlx/xlabuilder/xlabuilder.cpp
+++ b/c/gomlx/xlabuilder/xlabuilder.cpp
@@ -30,7 +30,6 @@
 #include "xla/hlo/builder/xla_computation.h"
 #include "xla/hlo/builder/lib/arithmetic.h"
 #include "xla/literal.h"
-#include "xla/statusor.h"
 #include "xla/types.h"
 #include "xla/xla_data.pb.h"
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Next
+
+* Replaced C++ `xla::StatusOr` by `absl::StatusOr` (the former was already an alias to the later).
+
 # v0.4.7 - 2024-11-17
 
 * Sync'ed with updated proto definitions from OpenXLA/XLA project.


### PR DESCRIPTION
The former was already just an alias to the later. XLA is going to remove the alias.