### PR TITLE
Pre-loaded plugins fix

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Package `xlabuilder`:
   * Added name of builder on the error message when trying to combine nodes from different builders.
 * Added `BitcastConvert` op.
+* Fixed `pjrt.AvailablePlugins()` to return statically pre-linked plugins. 
 
 # v0.6.0
 

--- a/pjrt/dynamiclib.go
+++ b/pjrt/dynamiclib.go
@@ -176,6 +176,16 @@ func searchPlugin(searchName string) (path string, found bool) {
 
 func searchPlugins(searchName string) (pluginsPaths map[string]string) {
 	pluginsPaths = make(map[string]string)
+
+	// Include plugins already (pre-)loaded.
+	for name, pluginPath := range loadedPlugins {
+		if searchName != "" && searchName != name {
+			continue
+		}
+		pluginsPaths[name] = pluginPath.Path()
+	}
+
+	// Search for plugins in other paths.
 	for _, pluginPath := range pluginSearchPaths {
 		for _, pattern := range []string{
 			"pjrt-plugin-*.so", "pjrt_plugin_*.so", "pjrt_c_api_*_plugin.so",


### PR DESCRIPTION
* Fixed `pjrt.AvailablePlugins()` to return statically pre-linked plugins. 
