### PR TITLE
Added memory usage information for a PJRT executable.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Gopjrt Changelog
 
-# Next
+# v0.6.1
 
 * Package `xlabuilder`:
   * Added name of builder on the error message when trying to combine nodes from different builders.
 * Added `BitcastConvert` op.
 * Fixed `pjrt.AvailablePlugins()` to return statically pre-linked plugins. 
+* Added memory usage information for executables: `pjrt.LoadedExecutable.OnDeviceMemoryUsageStats`
+  and `pjrt.LoadedExecutable.OnHostMemoryUsageStats`.
 
 # v0.6.0
 

--- a/pjrt/executables.go
+++ b/pjrt/executables.go
@@ -21,6 +21,25 @@ type Executable struct {
 	plugin      *Plugin
 }
 
+// ExecutableMemoryUsageStats reports the static memory usage for a compiled program, in bytes.
+// The on-device memory needed to run an executable is at least:
+// GeneratedCode + Inputs + Outputs - Aliases + Temporary. See ExecutableMemoryUsageStats.Requirements.
+//
+// Aliases is how much memory of the input is reused as output (?).
+//
+// The documentation is sparse in XLA, here are the links:
+//
+//   - xla::CompiledMemoryStats: https://github.com/openxla/xla/blob/2fff53249ed49930de14b235f50ed2235e69df8b/xla/pjrt/pjrt_executable.h#L284
+//   - PJRT C API:https://github.com/openxla/xla/blob/main/xla/pjrt/c/pjrt_c_api.h#L1668
+type ExecutableMemoryUsageStats struct {
+	GeneratedCode, Inputs, Outputs, Aliases, Temporary int64
+}
+
+// Requirements returns an estimate of memory requirements for the executable.
+func (m ExecutableMemoryUsageStats) Requirements() int64 {
+	return m.GeneratedCode + m.Inputs + m.Outputs - m.Aliases + m.Temporary
+}
+
 // newExecutable creates Executable and registers it for freeing.
 func newExecutable(plugin *Plugin, cExecutable *C.PJRT_Executable) *Executable {
 	e := &Executable{
@@ -86,4 +105,45 @@ func (e *Executable) Name() (string, error) {
 		return "", err
 	}
 	return cCharArray(args.executable_name, args.executable_name_size), nil
+}
+
+// GetMemoryStats returns the sizes (in bytes) for the compiled code, inputs, outputs, aliases and temporary memory
+// used both in host and on device.
+//
+// This can be used to estimate memory requirements for the program.
+func (e *Executable) GetMemoryStats() (onDevice, onHost ExecutableMemoryUsageStats, err error) {
+	if e == nil || e.plugin == nil || e.cExecutable == nil {
+		err = errors.New("Executable is nil, or its plugin or wrapped C representation is nil -- has it been destroyed already?")
+		return
+	}
+	defer runtime.KeepAlive(e)
+
+	arena := getArenaFromPool()
+	defer returnArenaToPool(arena)
+
+	var args *C.PJRT_Executable_GetCompiledMemoryStats_Args
+
+	args = arenaAlloc[C.PJRT_Executable_GetCompiledMemoryStats_Args](arena)
+	args.struct_size = C.PJRT_Executable_GetCompiledMemoryStats_Args_STRUCT_SIZE
+	args.executable = e.cExecutable
+	err = toError(e.plugin, C.call_PJRT_Executable_GetCompiledMemoryStats(e.plugin.api, args))
+	if err != nil {
+		return
+	}
+
+	onDevice = ExecutableMemoryUsageStats{
+		GeneratedCode: int64(args.generated_code_size_in_bytes),
+		Inputs:        int64(args.argument_size_in_bytes),
+		Outputs:       int64(args.output_size_in_bytes),
+		Aliases:       int64(args.alias_size_in_bytes),
+		Temporary:     int64(args.temp_size_in_bytes),
+	}
+	onHost = ExecutableMemoryUsageStats{
+		GeneratedCode: int64(args.host_generated_code_size_in_bytes),
+		Inputs:        int64(args.host_argument_size_in_bytes),
+		Outputs:       int64(args.host_output_size_in_bytes),
+		Aliases:       int64(args.host_alias_size_in_bytes),
+		Temporary:     int64(args.host_temp_size_in_bytes),
+	}
+	return
 }

--- a/pjrt/loadedexecutables.go
+++ b/pjrt/loadedexecutables.go
@@ -58,6 +58,9 @@ type LoadedExecutable struct {
 
 	// NumOutputs of the executable.
 	NumOutputs int
+
+	// OnDeviceMemoryUsageStats, OnHostMemoryUsageStats can be used to estimate the required memory usage for the executable on device (and on host).
+	OnDeviceMemoryUsageStats, OnHostMemoryUsageStats ExecutableMemoryUsageStats
 }
 
 var numLoadedExecutables atomic.Int64
@@ -93,6 +96,12 @@ func newLoadedExecutable(plugin *Plugin, client *Client, cLoadedExecutable *C.PJ
 	if err != nil {
 		e.destroyOrLog()
 		return nil, errors.WithMessagef(err, "failed to Executable.NumOutputs from compiled LoadedExecutable")
+	}
+
+	e.OnDeviceMemoryUsageStats, e.OnHostMemoryUsageStats, err = e.executable.GetMemoryStats()
+	if err != nil {
+		e.destroyOrLog()
+		return nil, errors.WithMessagef(err, "failed to Executable.GetMemoryStats from compiled LoadedExecutable")
 	}
 	return e, nil
 }

--- a/pjrt/loadedexecutables_test.go
+++ b/pjrt/loadedexecutables_test.go
@@ -1,6 +1,7 @@
 package pjrt
 
 import (
+	"fmt"
 	"github.com/gomlx/gopjrt/dtypes"
 	"github.com/gomlx/gopjrt/xlabuilder"
 	"github.com/stretchr/testify/require"
@@ -22,6 +23,10 @@ func TestDonatableConfig(t *testing.T) {
 	comp := capture(builder.Build(fX)).Test(t)
 	exec, err := client.Compile().WithComputation(comp).Done()
 	require.NoErrorf(t, err, "Failed to compile program")
+
+	fmt.Println("Memory usage:")
+	fmt.Printf("OnDevice: %+v\n", exec.OnDeviceMemoryUsageStats)
+	fmt.Printf("OnHost: %+v\n", exec.OnHostMemoryUsageStats)
 
 	// Test the ExecutionConfig:
 	c := exec.Execute(nil, nil, nil)                       // nil values, we are not going to actually execute it.


### PR DESCRIPTION
Added memory usage information for executables: `pjrt.LoadedExecutable.OnDeviceMemoryUsageStats`
  and `pjrt.LoadedExecutable.OnHostMemoryUsageStats`.