### PR TITLE
Fixed small memory leak of a VectorData wrapper #31

### DIFF
--- a/cbuffer/cbuffer.go
+++ b/cbuffer/cbuffer.go
@@ -68,7 +68,7 @@ func (b *CBuffer) Free() {
 
 // Bytes returns the buffer as a byte slice.
 //
-// Ownership is not transferred: remember to free CBuffer afterwards.
+// Ownership is not transferred: remember to free CBuffer afterward.
 func (b *CBuffer) Bytes() []byte {
 	if b.data == nil {
 		return nil

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gopjrt Changelog
 
+# Next
+
+* Fixed small memory leak of a VectorData wrapper when converting to HLO/StableHLO (#31).
+
 # v0.6.2 - 2025/02/26
 
 * Fixed C/C++ wrapper version.


### PR DESCRIPTION
Ref: #31 

Fixed small memory leak of a VectorData wrapper when converting to HLO/StableHLO (#31).