### PR TITLE
v0.7.0: Updated XLA, bumped version, plugin owned arenas.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ Untitled.ipynb
 # Links to C-generated code.
 bazel-bin
 bazel-c
+bazel-gopjrt
 bazel-out
 bazel-mnt
 bazel-testlogs

--- a/c/WORKSPACE
+++ b/c/WORKSPACE
@@ -21,12 +21,11 @@ http_archive(
 # Notice bazel.sh scrape the line below for the OpenXLA version, the format
 # of the line should remain the same (the hash in between quotes), or bazel.sh
 # must be changed accordingly.
-# OPENXLA_XLA_COMMIT_HASH = "a1a5e62fbffa3a3b6c409d72607456cf5b353a22"  # From 2025-01-28
-OPENXLA_XLA_COMMIT_HASH = "9f2aa85b909a615eef2212286f1e0c5684fc6b6c"  # From 2025-04-10
+OPENXLA_XLA_COMMIT_HASH = "dd2192e2ffd24f35843918b3bce3fd441034613e"  # From 2025-04-30
 
 http_archive(
     name = "xla",
-    sha256 = "633c392d1b24e6cd86a0dee764d83b72b6eee3ba8c323c81a3672908a5d6766e",  # From 2025-04-10
+    sha256 = "71518ca1802600f4b00e409101f2e61ad2032bddc2dd60ee1fd98a9f3bb3e704",  # From 2024-04-30
     strip_prefix = "xla-" + OPENXLA_XLA_COMMIT_HASH,
     urls = [
         "https://github.com/openxla/xla/archive/{hash}.zip".format(hash = OPENXLA_XLA_COMMIT_HASH),

--- a/c/gomlx/xlabuilder/shape.cpp
+++ b/c/gomlx/xlabuilder/shape.cpp
@@ -35,11 +35,12 @@ Shape *ShapeFromXlaShape(const xla::Shape &xla_shape) {
   Shape *shape = Malloc<Shape>();
   shape->dtype = int32_t(xla_shape.element_type());
   if (shape->dtype == xla::TUPLE) {
-    shape->tuple_size = xla_shape.tuple_shapes_size();
+    auto &tuple_shapes = xla_shape.tuple_shapes();
+    shape->tuple_size = tuple_shapes.size();
     if (shape->tuple_size > 0) {
       shape->tuple_shapes = Malloc<Shape *>(shape->tuple_size);
       for (int ii = 0; ii < shape->tuple_size; ii++) {
-        shape->tuple_shapes[ii] = ShapeFromXlaShape(xla_shape.tuple_shapes(ii));
+        shape->tuple_shapes[ii] = ShapeFromXlaShape(tuple_shapes[ii]);
       }
     }
     return shape;

--- a/c/gomlx/xlabuilder/xlabuilder.cpp
+++ b/c/gomlx/xlabuilder/xlabuilder.cpp
@@ -42,7 +42,7 @@ using namespace std;
 // This often lags behind Gopjrt version, if/when the C/C++ wrapper doesn't change --
 // we don't bump the version of the C/C++ code if it doesn't change.
 // But when it changes, it matches the Gopjrt version it's being released with.
-const char *GopjrtXlaBuilderVersion = "v0.6.3";
+const char *GopjrtXlaBuilderVersion = "v0.7.0";
 
 // ShapeFromXlaShape allocates and sets a new Shape struct set with the same
 // shape defined by xla::Shape. C++ only.

--- a/c/xla_configure.linux_amd64.bazelrc
+++ b/c/xla_configure.linux_amd64.bazelrc
@@ -1,10 +1,14 @@
-build --action_env GCC_HOST_COMPILER_PATH=/usr/bin/x86_64-linux-gnu-gcc-13
-build --action_env LD_LIBRARY_PATH=/usr/local/lib:/home/janpf/src/vcpkg/installed/x64-linux/lib
+build --action_env CLANG_COMPILER_PATH=/usr/lib/llvm-20/bin/clang
+build --repo_env CC=/usr/lib/llvm-20/bin/clang
+build --repo_env BAZEL_COMPILER=/usr/lib/llvm-20/bin/clang
+build --action_env LD_LIBRARY_PATH=/usr/local/lib:/home/janpf/.local/lib:/home/janpf/src/vcpkg/installed/x64-linux/lib
 build --action_env PYTHON_BIN_PATH=/usr/bin/python3
 build --python_path /usr/bin/python3
 test --test_env LD_LIBRARY_PATH
 test --test_size_filters small,medium
 build --copt -Wno-sign-compare
+build --copt -Wno-error=unused-command-line-argument
+build --copt -Wno-c23-extensions
 build --build_tag_filters -no_oss,-gpu
 build --test_tag_filters -no_oss,-gpu
 test --build_tag_filters -no_oss,-gpu

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Gopjrt Changelog
 
-# Next
+# v0.7.0 - 2024/04/30
 
 * Renamed Gather() parameter offsetAxes to offsetOutputAxes to avoid confusion.
 * Donated buffers given for execution are automatically destroyed after the execution -- since they are invalidated.

--- a/xlabuilder/xlabuilder.go
+++ b/xlabuilder/xlabuilder.go
@@ -33,7 +33,7 @@ func CVersion() string {
 //
 // This is needed because they can go out-of-sync in developers machines -- if one updates
 // the Go library, but not the corresponding C/C++ libgomlx_xlabuilder.so library.
-var MatchingCVersion = "v0.6.3"
+var MatchingCVersion = "v0.7.0"
 
 func init() {
 	if CVersion() != MatchingCVersion {


### PR DESCRIPTION
* Donated buffers given for execution are automatically destroyed after the execution -- since they are invalidated.
* The Plugin now owns the arena pool (as opposed to being a global resource). 

